### PR TITLE
Create Dockerfile for render_hcce.sh

### DIFF
--- a/community-edition/Dockerfile
+++ b/community-edition/Dockerfile
@@ -1,0 +1,12 @@
+from ubuntu:22.04
+
+RUN apt update && apt upgrade -y
+RUN apt install -y openssl npm gettext-base
+RUN mkdir -p /app
+WORKDIR /app
+COPY . .
+RUN chmod +x /app/render_hcce.sh
+
+RUN npm install pem-jwk -g
+
+CMD [ "/bin/bash", "-c", "/app/render_hcce.sh" ]

--- a/community-edition/readme.md
+++ b/community-edition/readme.md
@@ -41,17 +41,6 @@ kubectl apply -f ./hcce.yaml
 
 once the container has run, you should see a new file (hcce.yaml) in your COMMUNITY_EDITION_PATH
 
-To build the cbb.yaml file inside a docker container run the following:
-
-> Add your chosen services into `render_cbb.sh` with a text editor first
-
-```
-docker build . -t hubs-ce-builder-cbb:latest
-docker run --rm -it -v <COMMUNITY_EDITION_PATH>:/app hubs-ce-builder-cbb:latest
-```
-
-once the container has run, you should see a new file (cbb.yaml) in your COMMUNITY_EDITION_PATH
-
 ## Deploy to Kubernetes
 
 To deploy to your K8s cluster on your chosen hosting solution, follow these steps:

--- a/community-edition/readme.md
+++ b/community-edition/readme.md
@@ -26,6 +26,32 @@ Before deploying the charts in this repo, you will need to choose and configure 
   - UDP: 35000 -> 60000
 - An SMTP service for login emails and accounts
 
+# Optional Docker Builder
+
+To build the hcce.yaml file inside a docker container run the following:
+
+> Add your chosen services into `render_hcce.sh` with a text editor first
+
+```
+docker build . -t hubs-ce-builder:latest
+docker run --rm -it -v <COMMUNITY_EDITION_PATH>:/app hubs-ce-builder:latest
+# Then to deploy to k8
+kubectl apply -f ./hcce.yaml
+```
+
+once the container has run, you should see a new file (hcce.yaml) in your COMMUNITY_EDITION_PATH
+
+To build the cbb.yaml file inside a docker container run the following:
+
+> Add your chosen services into `render_cbb.sh` with a text editor first
+
+```
+docker build . -t hubs-ce-builder-cbb:latest
+docker run --rm -it -v <COMMUNITY_EDITION_PATH>:/app hubs-ce-builder-cbb:latest
+```
+
+once the container has run, you should see a new file (cbb.yaml) in your COMMUNITY_EDITION_PATH
+
 ## Deploy to Kubernetes
 
 To deploy to your K8s cluster on your chosen hosting solution, follow these steps:
@@ -102,16 +128,28 @@ Chris from MeTabi [has created a guide](https://github.com/hubs-community/import
 
 Replace `hcce-vm-1` and `us-central1-a` with your desired name and zone. Check [the official doc](https://cloud.google.com/sdk/gcloud/reference/compute/instances/create) for more options.
 
-```
+````
+
 ### login gcp
+
 gcloud auth login
+
 ### create a vm
+
 `gcloud compute instances create hcce-vm-1 --zone=us-central1-a`
+
 ### ssh to the vm
+
 `gcloud compute ssh --project=hubs-dev-333333 --zone=us-central1-a geng-test-2`
+
 ### prepare the vm
+
 `sudo apt update && sudo apt install npm && sudo npm install pem-jwk -g`
-### install k3s
+
+### install k3s without traefik -- read https://docs.k3s.io/ for more info
+
+- `curl https://get.k3s.io/ | INSTALL_K3S_EXEC="--disable=traefik" sh -`
+
 ```
 
 ##### Step 2: Install k3s without traefik
@@ -125,7 +163,29 @@ gcloud auth login
 - Add your services to `render_hcce.sh`
 - Run `bash render_hcce.sh && sudo k3s kubectl apply -f hcce.yaml`
 
-##### Step 4: Connect the ingress
+#### Step 3: connect the ingress
+- find the vm's external ip
+- create a-records to the dns
+- makesure the required ports are exposed to the client
+
+# example -- a "hello-world" instance with managed kubernetes on gcp
+#### Step 1: make a kubernetes environment
+replace `hcce-gke-1` and `us-central1-a` with your desired name and zone, check [official doc](https://cloud.google.com/sdk/gcloud/reference/container/clusters/create) for more options
+```
+
+# login gcp
+
+gcloud auth login
+
+# create gke cluster
+
+gcloud container clusters create hcce-gke-1 --zone=us-central1-a
+
+# get creds for kubectl
+
+gcloud container clusters get-credentials --region us-central1-a hcce-gke-1
+
+```
 
 - Find the vm's external IP
 - Expose IP to DNS
@@ -137,6 +197,33 @@ gcloud auth login
 
 ## Considerations for Production Environment
 
+# example -- a "potentially-somewhat-production-ready" instance on aws
+- comming soon
+
+# considerations for production environment
+- infra
+    - easy -- use a managed kubernetes
+    - hard -- https://kubernetes.io/docs/setup/production-environment/
+- security
+    - password and keys overview
+    - add a waf
+- scalability
+    - stateful services
+        - pgsql
+            - use a managed pgsql ie. rds on aws or cloudsql on gcp
+            - roll your own
+                - <links to some guides to run pgsql in k8s>
+        - reticulum
+            - use a network/shared storage for reticulum's /storage mount
+    - stateless services (all except reticulum and pgsql)
+        - just run multiple replicas
+        - use hpa
+- devops
+    - the yaml file is the entire infra on kubernetes, use a git to track changes and an ops pipeline to auto deploy
+        - ie put the yaml file on a github repo and use github action to deploy to your hosting env
+    - use dev env for staging/testing
+        - use spot instances for nodes to save $
+        - develop and integrate automated testing scripts into the ops pipeline
 - Infrastructure
   - Easy -- use managed kubernetes
   - Hard -- make it [production-ready](https://kubernetes.io/docs/setup/production-environment/)
@@ -160,3 +247,4 @@ gcloud auth login
     - Use spot instances for nodes to save money.
     - Develop and integrate automated testing scripts into the ops pipeline
   - Configure devops for deploying custom versions of Spoke, Hubs, and Reticulum
+```


### PR DESCRIPTION
This file allows for the bash scripts to be run without dependencies on the host machine. 

Mitigates the issues with escaping the private key (PERMS_KEY)

Usage:
`docker build . -t hubs-ce-builder:latest` then `docker run --rm -it -v REPLACE_PATH:/app hubs-ce-builder:latest` to build the yaml files

note: can be used for render_cbb.sh by changing render_hcce.sh to render_cbb.sh