### PR TITLE
Allow connecting to the official Hubs Foundation Hubs instance by default

### DIFF
--- a/community-edition/generate_script/hcce.yam
+++ b/community-edition/generate_script/hcce.yam
@@ -336,6 +336,9 @@ data:
     [ret."Elixir.Ret.Support"]
     slack_webhook_url = "<SLACK_WEBHOOK>"
 
+    # The values in the following section are added to the Content Security Policy.
+    # This is used to allow connections to external URLs.
+    # Adding URLs that are local to your cluster is unnecessary.
     [ret."Elixir.RetWeb.Plugs.AddCSP"]
     child_src = ""
     connect_src = "demo.hubsfoundation.org *.demo.hubsfoundation.org"


### PR DESCRIPTION
Scenes from the official Hubs Foundation instance can't be remixed properly unless that instance is added to the allow lists in the Reticulum config and as a non cors proxy domain.  Adding this should also prevent any other resolution errors for content from the official Hubs Foundation instance.

This commit also removes the outdated link to nearspark.reticulum.io.