### PR TITLE
feat: add liveness and readiness probes to dialog deployment

### DIFF
--- a/community-edition/generate_script/hcce.yam
+++ b/community-edition/generate_script/hcce.yam
@@ -1093,18 +1093,36 @@ spec:
     spec:
       hostNetwork: true
       containers:
-      - name: dialog
-        image: $Container_Dockerhub_Username/dialog:$Container_Tag
-        imagePullPolicy: Always
-        ports:
-        - hostPort: 4443
-          containerPort: 4443
-        env:
-        - name: perms_key
-          valueFrom:
-            secretKeyRef:
-              name: configs
-              key: PERMS_KEY
+        - name: dialog
+          image: $Container_Dockerhub_Username/dialog:$Container_Tag
+          imagePullPolicy: Always
+          ports:
+          - hostPort: 4443
+            containerPort: 4443
+          env:
+          - name: perms_key
+            valueFrom:
+              secretKeyRef:
+                name: configs
+                key: PERMS_KEY
+            readinessProbe:
+              httpGet:
+                path: https://localhost/health
+                port: 4443
+                scheme: HTTPS
+              initialDelaySeconds: 10
+              periodSeconds: 5
+              timeoutSeconds: 3
+              failureThreshold: 6
+            livenessProbe:
+              httpGet:
+                path: https://localhost/health
+                port: 4443
+                scheme: HTTPS
+              initialDelaySeconds: 30
+              periodSeconds: 10
+              timeoutSeconds: 3
+              failureThreshold: 3
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
## What?

This PR  adds   adds Kubernetes readiness and liveness probes to the `dialog` deployment in `community-edition/generate_script/hcce.yam`.

---

## Why?

The `dialog` service currently =does not have any Kubernetes health monitoring. This PR adds the readiness and liveness that the  probes allows Kubernetes to:

* delay traffic until the service is ready
* automatically restart the container if it becomes unresponsive

For these reasons, this is aligns with standard Kubernetes best practices for service reliability for creating a PR.

---

## Notes

* This work the  uses the `health` endpoint referenced in `Hubs-Foundation/dialog#61`.
* The initial timing values are also intentionally conservative, since the readiness timing is not yet well characterized. (Coudl be future work?) 
* Probes are then configured  over HTTPS on port `4443`, matching the existing dialog deployment.

---

## Examples

N/A

---

## How to test

1. Apply the updated deployment (or regenerate manifests if using the CE scripts).
2. Deploy to a Kubernetes cluster:

   ```bash
   kubectl apply -f community-edition/generate_script/hcce.yam
   ```
3. Verify the `dialog` pod:

   ```bash
   kubectl get pods
   kubectl describe pod <dialog-pod-name>
   ```
4. Confirm that , based on the results of these actions : 

   * readiness and liveness probes are present in the pod spec
   * the pod transitions to `Ready`
5. Optionally:

   * simulate failure (e.g., put some sort of block on  the endpoint or a similar sort of signal one may have to look for) and then look to confirm if Kubernetes restarts the container

---

## Documentation of functionality

No additional documentation changes are required. This is a deployment configuration improvement within `hcce.yam`.

---

## Limitations

* The exact readiness timing characteristics are not fully known, so probe timings may need adjustment based on real-world behavior.
* This assumes the health endpoint referenced in `dialog#61` is stable and available.

---

## Alternative implementations considered

* Using more advanced health signals (e.g., memory usage thresholds) for liveness detection, but a simple HTTP probe was chosen as a practical and reliable starting point.

---

## Open questions

* Whether `/health` is the best long-term endpoint or if `/healthz` (used elsewhere in the repo) should be standardized across services.
* Whether probe timing values should be tuned further based on observed startup behavior.

---

## Additional details or related context

* Related issue: #392
* Follows Kubernetes best practices for service health monitoring.
