### PR TITLE
Restrict default-branch-pr-guard workflow to minimum required permissions and apply Zizmor fixes

### DIFF
--- a/.github/workflows/default-branch-pr-guard.yml
+++ b/.github/workflows/default-branch-pr-guard.yml
@@ -15,6 +15,8 @@ on:
       - enqueued
       - ready_for_review
 
+permissions: {}
+
 jobs:
   default-branch-pr-guard:
     runs-on: ubuntu-latest

--- a/.github/workflows/default-branch-pr-guard.yml
+++ b/.github/workflows/default-branch-pr-guard.yml
@@ -24,5 +24,9 @@ jobs:
       - name: Prevent unsanctioned pull requests to the default branch
         if: github.base_ref == github.event.repository.default_branch && (github.head_ref != 'development' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name)
         run: |
-          echo "ERROR: You are only allowed to merge to the '${{ github.event.repository.default_branch }}' branch from this repository's 'development' branch.  base_ref: ${{ github.base_ref }}; head_ref: ${{ github.head_ref }}; base_repo: ${{ github.event.pull_request.base.repo.full_name }}; head_repo: ${{ github.event.pull_request.head.repo.full_name }}; "
+          echo "ERROR: You are only allowed to merge to the '${GITHUB_EVENT_REPOSITORY_DEFAULT_BRANCH}' branch from this repository's 'development' branch.  base_ref: ${GITHUB_BASE_REF}; head_ref: ${GITHUB_HEAD_REF}; base_repo: ${GITHUB_EVENT_PULL_REQUEST_BASE_REPO_FULL_NAME}; head_repo: ${GITHUB_EVENT_PULL_REQUEST_HEAD_REPO_FULL_NAME}; "
           exit 1
+        env:
+          GITHUB_EVENT_REPOSITORY_DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          GITHUB_EVENT_PULL_REQUEST_BASE_REPO_FULL_NAME: ${{ github.event.pull_request.base.repo.full_name }}
+          GITHUB_EVENT_PULL_REQUEST_HEAD_REPO_FULL_NAME: ${{ github.event.pull_request.head.repo.full_name }}


### PR DESCRIPTION
## What?
<!-- REQUIRED — Explain what your pull request does -->
Sets the permissions of the default-branch-pr-guard workflow to none and replaces direct use of the GitHub variables in the shell execution with indirect usage via shell variables.

## Why?
<!-- REQUIRED — Explain why you're opening this pull request, what limitations does it address, etc..  If you're fixing a bug with an open bug report you can just link to the bug report -->
To increase its security and in preparation to globally restrict permissions for all Hubs Foundation workflows.

## Examples
<!-- OPTIONAL — If applicable, give examples of the changes the user will observe, e.g. screenshots, videos, diagrams, console output, etc., otherwise put "N/A" or remove the section.  Including examples of before the PR and after the PR is encouraged. -->
N/A

## How to test
<!-- REQUIRED — Give the steps required to test your pull request -->

1. Add the changes from this PR to your master branch and push it to your fork.
2. Create a new branch (based off of the updated master branch) with a minor change and push that to your fork.
3. Create a pull request from the new branch on your fork to the updated master branch on your fork.
4. See that the workflow still works as expected with the new changes.

In the short term (and if you have the required permissions), you can just check a recent run of the updated workflow from this PR, e.g.: https://github.com/Hubs-Foundation/hubs-cloud/actions/runs/28285184986/job/83807817462

To verify that all the Zizmor issues have been addressed, run the following command from the repository folder and see that Zizmor reports no issues (that we care about) for the default-branch-pr-guard workflow.
```
docker run --rm --name zizmor -v .:/usr/repo ghcr.io/zizmorcore/zizmor --fix=all /usr/repo
```

## Documentation of functionality
<!-- REQUIRED — Link to the accompanying documentation pull request or identify where the documentation is located in this pull request.  If no documentation is needed, please specify this here -->
This doesn't change the functionality of the workflow, so no documentation update is needed.

## Limitations
<!-- OPTIONAL — If there is anything you decided not to do/support in this PR that might otherwise be expected, list them here along with the reason why you didn't do/support them, otherwise put "None" -->
None

## Alternative implementations considered
<!-- OPTIONAL — If there are any alternative ways of implementing this change that you thought of, but decided against, list them here along with why they were discarded, otherwise put "None" -->
None

## Open questions
<!-- OPTIONAL — If you have any questions, put them here, otherwise put "None" -->
What is the best way to apply this to both the master branch and the development branch, since we can't currently merge the development branch into master?
* Merge this PR to master and then rebase the development branch?
* Merge the PR and then merge the master branch into the development branch?
* Something else?

Note: for the roadmap auto commenter it looks like I merged the PR and then merged the master branch into the development branch.  Should I just do that again?

UPDATE: It was initially decided at the [2026-07-07 Hubs Dev Meetup](https://docs.google.com/document/d/1OMh3-_DpjHABMMrXtECzLPNxipQMixx32l6K4zqSoYY/edit?tab=t.0#heading=h.2evylzzbp6g5) that we would rebase the development branch, however that resulted in the loss of the merge commits that were present on the development branch, so it was decided at the [2026-07-14 Hubs Dev Meetup](https://docs.google.com/document/d/1OMh3-_DpjHABMMrXtECzLPNxipQMixx32l6K4zqSoYY/edit?tab=t.0#heading=h.8ug10qyiv63z) that we would instead merge the master branch into the development branch.

## Additional details or related context
<!-- OPTIONAL — If there are any other details that you think the reviewers should be aware of that you didn't put elsewhere, e.g. links to related issues, pull requests, references you used, notes on weird things, attribution, etc., put them here, otherwise put "None" -->
Part of https://github.com/Hubs-Foundation/.github/issues/13

This doesn't touch any of the workflows in the services folder since GitHub doesn't pick them up.