### PR TITLE
Support Kubernetes 1.34+ on DigitalOcean

### DIFF
--- a/community-edition/generate_script/hcce.yam
+++ b/community-edition/generate_script/hcce.yam
@@ -1248,6 +1248,11 @@ spec:
         - --ingress.class=haproxy
         - --log=warning #error warning info debug trace
         - --default-ssl-certificate=$Namespace/cert-hcce
+        resources:
+            requests:
+              memory: "1Mi"
+            limits:
+              memory: "1Ti"
         securityContext:
           runAsUser:  1000
           runAsGroup: 1000


### PR DESCRIPTION
## What?
<!-- REQUIRED — Explain what your pull request does -->
Adds a memory request/limit to Haproxy.

## Why?
<!-- REQUIRED — Explain why you're opening this pull request, what limitations does it address, etc..  If you're fixing a bug with an open bug report you can just link to the bug report -->
Starting with Kubernetes 1.34, DigitalOcean kills Haproxy (and also Reticulum and Photomnemonic, for some reason) shortly after startup because it thinks it's using too much memory.  Adding the limit to Haproxy seems to fix everything (possibly because it increases the QoS Class of the pod from "BestEffort" to "Burstable", though I'm not sure why this fixes the Reticulum and Photomnemonic pods as they're still "BestEffort").  The extremely low request and extremely high limit should essentially preserve the previous behavior and make it so it just uses whatever memory it needs (which is normally around 30-40 Mi to begin with).

## Examples
<!-- OPTIONAL — If applicable, give examples of the changes the user will observe, e.g. screenshots, videos, diagrams, console output, etc., otherwise put "N/A" or remove the section.  Including examples of before the PR and after the PR is encouraged. -->
N/A

## How to test
<!-- REQUIRED — Give the steps required to test your pull request -->

1. Regenerate your hcce.yaml file with `npm run gen-hcce` (remember to create a backup of hcce.yaml first if you have customized it).
2. Comment out the `- --default-ssl` line in hcce.yaml
3. Run these commands to completely restart your instance:
    - `kubectl delete deployment --all -n hcce`
    - `kubectl delete pods --all -n hcce`
    - `npm run apply`
4. Visit your instance and see that everything works.
5. If you are using DigitalOcean and/or on a version of Kubernetes before 1.34, you should see no difference with these changes. 
6. If you are using DigitalOcean and/or on a version of Kubernetes of 1.34+, you should see that without these changes, your instance won't work and will be stuck with pods in a CrashLoopBackOff state due to being continually killed for being out of memory; however, with these changes you should see that things work normally.

## Documentation of functionality
<!-- REQUIRED — Link to the accompanying documentation pull request or identify where the documentation is located in this pull request.  If no documentation is needed, please specify this here -->
This PR preserves the previous behavior, so no documentation update is needed.

## Known limitations
<!-- OPTIONAL — If there is anything you decided not to do/support in this PR that might otherwise be expected, list them here along with the reason why you didn't do/support them, otherwise put "None" -->
This doesn't add memory requests/limits to Reticulum, Photomnemonic, or any other pods.

## Alternative implementations considered
<!-- OPTIONAL — If there are any alternative ways of implementing this change that you thought of, but decided against, list them here along with why they were discarded, otherwise put "None" -->
Adding more constrained memory requests/limits, but it is unclear how much memory Haproxy really needs, and the default example has it with a minimum of 2Gi (and this was apparently in response to a bug: https://github.com/haproxytech/kubernetes-ingress/commit/ff82484be78dc631a867042dca5b7cca521059fe).  Since that's much higher than we usually see it with Hubs, giving it an essentially unlimited amount to preserve the previous behavior seemed better than more constrained settings.

Adding requests/limits to other pods, but this isn't required to fix the issue and it would be more complicated, and potentially require changes to allow auto-calculation based on a user provided value for the total memory of their instance (which would also necessitate a docs update).

## Open questions
<!-- OPTIONAL — If you have any questions, put them here, otherwise put "None" -->
None.

## Additional details or related context
<!-- OPTIONAL — If there are any other details that you think the reviewers should be aware of that you didn't put elsewhere, e.g. links to related issues, pull requests, references you used, notes on weird things, attribution, etc., put them here, otherwise put "None" -->


The memory used by the Reticulum pod has increased dramatically (from beginning with a few hundred Mi to beginning with around seventeen hundred Mi), but it's unclear why.